### PR TITLE
Lowercase the unit_of_measurement for aqi.

### DIFF
--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -79,7 +79,7 @@ class AirQualityIndex(SensorEntity):
 
     @property
     def unit_of_measurement(self):
-        return "AQI"
+        return "aqi"
 
     @property
     def icon(self):


### PR DESCRIPTION
While I agree that 'AQI' feels like a better choice this change matches the values reported by the official AirNow integration, allowing values from both to appear on the same graph.