### PR TITLE
use single CowayClient object, improved conformation to PEP8

### DIFF
--- a/custom_components/coway/__init__.py
+++ b/custom_components/coway/__init__.py
@@ -1,4 +1,4 @@
-""" Coway Component """
+"""Coway Component."""
 from __future__ import annotations
 
 import asyncio
@@ -7,13 +7,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
-
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import CowayDataUpdateCoordinator
-from .util import NoPurifiersError
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """ Set up Coway from a config entry. """
+    """Set up Coway from a config entry."""
 
     coordinator = CowayDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
@@ -23,14 +22,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return True
 
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """ Unload Coway config entry. """
+    """Unload Coway config entry."""
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         del hass.data[DOMAIN][entry.entry_id]
         if not hass.data[DOMAIN]:
             del hass.data[DOMAIN]
     return unload_ok
+
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""

--- a/custom_components/coway/config_flow.py
+++ b/custom_components/coway/config_flow.py
@@ -1,6 +1,6 @@
-""" Config Flow for Coway integration """
-
+"""Config Flow for Coway integration."""
 from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any
 
@@ -15,6 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from .const import DEFAULT_NAME, DOMAIN
 from .util import async_validate_api, NoPurifiersError
 
+
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
@@ -24,14 +25,14 @@ DATA_SCHEMA = vol.Schema(
 
 
 class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """ Handle a config flow for Coway integration. """
+    """Handle a config flow for Coway integration."""
 
     VERSION = 2
 
     entry: config_entries.ConfigEntry | None
 
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
-        """ Handle re-authentication with Coway. """
+        """Handle re-authentication with Coway."""
 
         self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         return await self.async_step_reauth_confirm()
@@ -39,7 +40,7 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(
             self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """ Confirm re-authentication with Coway. """
+        """Confirm re-authentication with Coway."""
 
         errors: dict[str, str] = {}
 
@@ -47,7 +48,7 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
             try:
-                access_token, refresh_token = await async_validate_api(self.hass, username, password)
+                await async_validate_api(self.hass, username, password)
             except AuthError:
                 errors["base"] = "invalid_auth"
             except ConnectionError:
@@ -63,13 +64,10 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         **self.entry.data,
                         CONF_USERNAME: username,
                         CONF_PASSWORD: password,
-                        'initial_access_token': access_token,
-                        'initial_refresh_token': refresh_token,
                     },
                 )
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
-                errors["base"] = "incorrect_user_pass"
 
         return self.async_show_form(
             step_id="reauth_confirm",
@@ -80,16 +78,15 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
             self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """ Handle the initial step. """
+        """Handle the initial step."""
 
         errors: dict[str, str] = {}
 
         if user_input:
-
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
             try:
-                access_token, refresh_token = await async_validate_api(self.hass, username, password)
+                await async_validate_api(self.hass, username, password)
             except AuthError:
                 errors["base"] = "invalid_auth"
             except ConnectionError:
@@ -105,8 +102,6 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_USERNAME: username,
                         CONF_PASSWORD: password,
-                        'initial_access_token': access_token,
-                        'initial_refresh_token': refresh_token,
                     },
                 )
 

--- a/custom_components/coway/const.py
+++ b/custom_components/coway/const.py
@@ -1,28 +1,28 @@
-""" Constants for Coway """
+"""Constants for Coway."""
 
 import asyncio
 import logging
 
 from aiohttp.client_exceptions import ClientConnectionError
+from cowayaio.exceptions import AuthError, CowayError
 
 from homeassistant.const import Platform
 from homeassistant.util.percentage import ordered_list_item_to_percentage
 
-from cowayaio.exceptions import AuthError, CowayError
 
 LOGGER = logging.getLogger(__package__)
 
 DEFAULT_SCAN_INTERVAL = 30
+TIMEOUT = 20
+DEFAULT_NAME = "Coway IoCare"
 DOMAIN = "coway"
+
 PLATFORMS = [
     Platform.FAN,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]
-
-DEFAULT_NAME = "Coway IoCare"
-TIMEOUT = 20
 
 COWAY_ERRORS = (
     asyncio.TimeoutError,

--- a/custom_components/coway/coordinator.py
+++ b/custom_components/coway/coordinator.py
@@ -1,40 +1,32 @@
-""" DataUpdateCoordinator for the Coway integration. """
+"""DataUpdateCoordinator for the Coway integration."""
 from __future__ import annotations
 
 from datetime import timedelta
 
-from cowayaio import CowayClient
 from cowayaio.exceptions import AuthError, CowayError
 from cowayaio.purifier_model import PurifierData
-
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, TIMEOUT
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .util import COWAY_CLIENT
 
 
 class CowayDataUpdateCoordinator(DataUpdateCoordinator):
-    """ Coway Data Update Coordinator. """
+    """Coway Data Update Coordinator."""
 
     data: PurifierData
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """ Initialize the Coway coordinator. """
+        """Initialize the Coway coordinator."""
 
-        self.hass = hass
-        self.entry = entry
-        self.entry_data = entry.data
-        self.client = CowayClient(
-            self.entry_data[CONF_USERNAME],
-            self.entry_data[CONF_PASSWORD],
-            session=async_get_clientsession(self.hass),
-            timeout=TIMEOUT,
-        )
+        COWAY_CLIENT.username = entry.data[CONF_USERNAME]
+        COWAY_CLIENT.password = entry.data[CONF_PASSWORD]
+        self.client = COWAY_CLIENT
         super().__init__(
             hass,
             LOGGER,
@@ -43,42 +35,16 @@ class CowayDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self) -> PurifierData:
-        """Fetch data from Coway.
-        After the config entry is created for the first time,the initial
-        coordinator update needs to reuse the access and refresh tokens
-        obtained via the async_validate_api method. If not, Coway servers
-        don't return an auth code. After the first data fetch, the initial
-        access and refresh tokens can be removed from the config entry.
-        """
-        
-        if 'initial_access_token' in self.entry_data:
-            self.client.access_token = self.entry.data['initial_access_token']
-            self.client.refresh_token = self.entry.data['initial_refresh_token']
-            try:
-                data = await self.client.async_get_purifiers_data()
-            except AuthError as error:
-                raise ConfigEntryAuthFailed from error
-            except CowayError as error:
-                raise UpdateFailed(error) from error
+        """Fetch data from Coway."""
 
-            if not data.purifiers:
-                raise UpdateFailed("No Purifiers found")
-            self.hass.config_entries.async_update_entry(
-                self.entry,
-                data={
-                    CONF_USERNAME: self.entry_data[CONF_USERNAME],
-                    CONF_PASSWORD: self.entry_data[CONF_PASSWORD],
-                }
-            )
-            self.entry_data = {CONF_USERNAME: self.entry.data[CONF_USERNAME],CONF_PASSWORD: self.entry.data[CONF_PASSWORD]}
-            return data
-        else:
-            try:
-                data = await self.client.async_get_purifiers_data()
-            except AuthError as error:
-                raise ConfigEntryAuthFailed from error
-            except CowayError as error:
-                raise UpdateFailed(error) from error
-            if not data.purifiers:
-                raise UpdateFailed("No Purifiers found")
-            return data
+        try:
+            data = await self.client.async_get_purifiers_data()
+        except AuthError as error:
+            raise ConfigEntryAuthFailed from error
+        except CowayError as error:
+            raise UpdateFailed(error) from error
+
+        if not data.purifiers:
+            raise UpdateFailed("No Purifiers found")
+
+        return data

--- a/custom_components/coway/fan.py
+++ b/custom_components/coway/fan.py
@@ -1,13 +1,12 @@
-""" Fan platform for Coway integration. """
+"""Fan platform for Coway integration."""
 from __future__ import annotations
 
 from typing import Any
 import asyncio
 
-
 from cowayaio.purifier_model import CowayPurifier
-from homeassistant.components.fan import FanEntity, FanEntityFeature
 
+from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -23,8 +22,8 @@ from .const import (
     PRESET_MODE_AUTO,
     PRESET_MODE_NIGHT,
 )
-
 from .coordinator import CowayDataUpdateCoordinator
+
 
 HASS_FAN_SPEED_TO_IOCARE = {v: k for (k, v) in IOCARE_FAN_SPEED_TO_HASS.items()}
 
@@ -32,12 +31,11 @@ HASS_FAN_SPEED_TO_IOCARE = {v: k for (k, v) in IOCARE_FAN_SPEED_TO_HASS.items()}
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """ Set Up Coway Fan Entities. """
+    """Set Up Coway Fan Entities."""
 
     coordinator: CowayDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     fans = []
-
 
     for purifier_id, purifier_data in coordinator.data.purifiers.items():
             fans.extend((
@@ -48,7 +46,7 @@ async def async_setup_entry(
 
 
 class Purifier(CoordinatorEntity, FanEntity):
-    """ Representation of a Coway Airmega air purifier. """
+    """Representation of a Coway Airmega air purifier."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -56,13 +54,13 @@ class Purifier(CoordinatorEntity, FanEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -73,37 +71,37 @@ class Purifier(CoordinatorEntity, FanEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_purifier'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "Purifier"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def is_on(self) -> bool:
-        """ Return true if the purifier is on. """
+        """Return true if the purifier is on."""
 
         return self.purifier_data.is_on
 
     @property
     def preset_modes(self) -> list:
-        """ Return the available preset modes. """
+        """Return the available preset modes."""
 
         return PRESET_MODES
 
     @property
     def preset_mode(self) -> str:
-        """" Return the current preset mode. """
+        """"Return the current preset mode."""
 
         if self.purifier_data.auto_eco_mode or self.purifier_data.auto_mode:
             return PRESET_MODE_AUTO
@@ -112,7 +110,7 @@ class Purifier(CoordinatorEntity, FanEntity):
 
     @property
     def percentage(self) -> int:
-        """ Return the current speed. """
+        """Return the current speed."""
 
         if not self.is_on:
             return 0
@@ -120,19 +118,19 @@ class Purifier(CoordinatorEntity, FanEntity):
 
     @property
     def speed_count(self) -> int:
-        """ Get length of available speeds list. """
+        """Get length of available speeds list."""
 
         return len(ORDERED_NAMED_FAN_SPEEDS)
 
     @property
     def supported_features(self) -> int:
-        """ Return supported features. """
+        """Return supported features."""
 
         return FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True
@@ -140,7 +138,7 @@ class Purifier(CoordinatorEntity, FanEntity):
             return False
 
     async def async_turn_on(self, percentage: int = None, **kwargs) -> None:
-        """ Turn the air purifier on. """
+        """Turn the air purifier on."""
 
         if percentage is not None:
             speed = HASS_FAN_SPEED_TO_IOCARE.get(percentage)
@@ -162,7 +160,7 @@ class Purifier(CoordinatorEntity, FanEntity):
             await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
-        """ Turn the air purifier off. """
+        """Turn the air purifier off."""
 
         await self.coordinator.client.async_set_power(self.purifier_data.device_attr, False)
         self.purifier_data.is_on = False
@@ -171,7 +169,7 @@ class Purifier(CoordinatorEntity, FanEntity):
         await self.coordinator.async_request_refresh()
 
     async def async_set_percentage(self, percentage: int) -> None:
-        """ Set the fan speed of the air purifier. """
+        """Set the fan speed of the air purifier."""
 
         if percentage == 0:
             await self.async_turn_off()
@@ -188,7 +186,7 @@ class Purifier(CoordinatorEntity, FanEntity):
                 await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """ Set a preset mode for the purifier. """
+        """Set a preset mode for the purifier."""
 
         if not self.is_on:
             await self.coordinator.client.async_set_power(self.purifier_data.device_attr, True)
@@ -205,5 +203,6 @@ class Purifier(CoordinatorEntity, FanEntity):
             self.purifier_data.auto_mode = False
             self.purifier_data.night_mode = True
             self.purifier_data.fan_speed = IOCARE_FAN_OFF
+
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()

--- a/custom_components/coway/manifest.json
+++ b/custom_components/coway/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "coway",
   "name": "Coway IoCare",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "config_flow": true,
   "iot_class": "cloud_polling",
   "documentation": "https://github.com/RobertD502/home-assistant-iocare/blob/main/README.md",

--- a/custom_components/coway/select.py
+++ b/custom_components/coway/select.py
@@ -1,12 +1,11 @@
-""" Select platform for Coway integration. """
+"""Select platform for Coway integration."""
 from __future__ import annotations
 
 from typing import Any
 
-
 from cowayaio.purifier_model import CowayPurifier
-from homeassistant.components.select import SelectEntity
 
+from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,18 +19,18 @@ from .const import (
 )
 from .coordinator import CowayDataUpdateCoordinator
 
+
 HASS_TIMER_TO_IOCARE = {v: k for (k, v) in IOCARE_TIMERS_TO_HASS.items()}
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """ Set Up Coway Select Entities. """
+    """Set Up Coway Select Entities."""
 
     coordinator: CowayDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     selects = []
-
 
     for purifier_id, purifier_data in coordinator.data.purifiers.items():
             selects.extend((
@@ -41,7 +40,7 @@ async def async_setup_entry(
     async_add_entities(selects)
 
 class Timer(CoordinatorEntity, SelectEntity):
-    """ Representation of purifier timer. """
+    """Representation of purifier timer."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -49,13 +48,13 @@ class Timer(CoordinatorEntity, SelectEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -66,25 +65,25 @@ class Timer(CoordinatorEntity, SelectEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_timer'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "Current timer"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def icon(self) -> str:
-        """ Set icon. """
+        """Set icon."""
 
         if self.current_option is "OFF":
             return 'mdi:timer-off'
@@ -93,19 +92,19 @@ class Timer(CoordinatorEntity, SelectEntity):
 
     @property
     def current_option(self) -> str:
-        """ Returns currently active timer. """
+        """Returns currently active timer."""
 
         return IOCARE_TIMERS_TO_HASS.get(self.purifier_data.timer)
 
     @property
     def options(self) -> list:
-        """ Return list of all the available timers. """
+        """Return list of all the available timers."""
 
         return IOCARE_TIMERS
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True
@@ -113,7 +112,7 @@ class Timer(CoordinatorEntity, SelectEntity):
             return False
 
     async def async_select_option(self, option: str) -> None:
-        """ Change the selected option. """
+        """Change the selected option."""
 
         if self.purifier_data.is_on:
             time = HASS_TIMER_TO_IOCARE.get(option)
@@ -124,6 +123,7 @@ class Timer(CoordinatorEntity, SelectEntity):
             LOGGER.error(f'Setting a timer for {self.purifier_data.device_attr["name"]} can only be done when the purifier is On.')
             self.purifier_data.timer = '0'
             self.purifier_data.timer_remaining = '0'
+
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -1,9 +1,9 @@
-""" Sensor platform for Coway integration."""
+"""Sensor platform for Coway integration."""
 from __future__ import annotations
 
+from datetime import time
 from typing import Any
 
-from datetime import time
 from cowayaio.purifier_model import CowayPurifier
 
 from homeassistant.components.sensor import (
@@ -11,13 +11,11 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import(
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
 )
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -25,10 +23,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import CowayDataUpdateCoordinator
 
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """ Set Up Coway Sensor Entities. """
+    """Set Up Coway Sensor Entities."""
 
     coordinator: CowayDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
@@ -48,7 +47,7 @@ async def async_setup_entry(
 
 
 class AirQualityIndex(CoordinatorEntity, SensorEntity):
-    """ Representation of AQI as reported by purifier. """
+    """Representation of AQI as reported by purifier."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -56,13 +55,13 @@ class AirQualityIndex(CoordinatorEntity, SensorEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -73,57 +72,58 @@ class AirQualityIndex(CoordinatorEntity, SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_aqi'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "AQI"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def native_value(self) -> float:
-        """ Return current AQI measurement. """
+        """Return current AQI measurement."""
 
         return round(float(self.purifier_data.air_quality_index), 1)
 
     @property
     def device_class(self) -> SensorDeviceClass:
-        """ Return entity device class. """
+        """Return entity device class."""
 
         return SensorDeviceClass.AQI
 
     @property
     def state_class(self) -> SensorStateClass:
-        """ Return state class type. """
+        """Return state class type."""
 
         return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
-        """ Set icon for entity. """
+        """Set icon for entity."""
 
         return 'mdi:air-filter'
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True
         else:
             return False
 
+
 class PreFilter(CoordinatorEntity, SensorEntity):
-    """ Representation of pre-filter percentage remaining. """
+    """Representation of pre-filter percentage remaining."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -131,13 +131,13 @@ class PreFilter(CoordinatorEntity, SensorEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -148,49 +148,49 @@ class PreFilter(CoordinatorEntity, SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_pre_filter'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "Pre filter"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def native_value(self) -> int:
-        """ Return current pre-filter percentage. """
+        """Return current pre-filter percentage."""
 
         return self.purifier_data.pre_filter_pct
 
     @property
     def native_unit_of_measurement(self) -> str:
-        """ Return unit of measurement. """
+        """Return unit of measurement."""
 
         return PERCENTAGE
 
     @property
     def state_class(self) -> SensorStateClass:
-        """ Return state class type. """
+        """Return state class type."""
 
         return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
-        """ Set icon for entity. """
+        """Set icon for entity."""
 
         return 'mdi:air-filter'
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True
@@ -199,7 +199,7 @@ class PreFilter(CoordinatorEntity, SensorEntity):
 
 
 class MAX2Filter(CoordinatorEntity, SensorEntity):
-    """ Representation of MAX2 filter percentage remaining. """
+    """Representation of MAX2 filter percentage remaining."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -207,13 +207,13 @@ class MAX2Filter(CoordinatorEntity, SensorEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -224,57 +224,58 @@ class MAX2Filter(CoordinatorEntity, SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_max_filter'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "MAX2 filter"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def native_value(self) -> int:
-        """ Return current MAX2 filter percentage. """
+        """Return current MAX2 filter percentage."""
 
         return self.purifier_data.max2_pct
 
     @property
     def native_unit_of_measurement(self) -> str:
-        """ Return unit of measurement. """
+        """Return unit of measurement."""
 
         return PERCENTAGE
 
     @property
     def state_class(self) -> SensorStateClass:
-        """ Return state class type. """
+        """Return state class type."""
 
         return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
-        """ Set icon for entity. """
+        """Set icon for entity."""
 
         return 'mdi:air-filter'
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True
         else:
             return False
 
+
 class ParticulateMatter10(CoordinatorEntity, SensorEntity):
-    """ Representation of PM10 measurement. """
+    """Representation of PM10 measurement."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -282,13 +283,13 @@ class ParticulateMatter10(CoordinatorEntity, SensorEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -299,63 +300,64 @@ class ParticulateMatter10(CoordinatorEntity, SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_particulate_matter_1_0'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "Particulate matter 10"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def native_value(self) -> int:
-        """ Return current PM10 measurement. """
+        """Return current PM10 measurement."""
 
         return self.purifier_data.particulate_matter_10
 
     @property
     def native_unit_of_measurement(self) -> str:
-        """ Return unit of measurement. """
+        """Return unit of measurement."""
 
         return CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @property
     def device_class(self) -> SensorDeviceClass:
-        """ Return entity device class. """
+        """Return entity device class."""
 
         return SensorDeviceClass.PM10
 
     @property
     def state_class(self) -> SensorStateClass:
-        """ Return state class type. """
+        """Return state class type."""
 
         return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
-        """ Set icon for entity. """
+        """Set icon for entity."""
 
         return 'mdi:air-filter'
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True
         else:
             return False
 
+
 class TimerRemaining(CoordinatorEntity, SensorEntity):
-    """ Representation of time left on timer. """
+    """Representation of time left on timer."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -363,13 +365,13 @@ class TimerRemaining(CoordinatorEntity, SensorEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -380,25 +382,25 @@ class TimerRemaining(CoordinatorEntity, SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_timer_remaining'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "Timer remaining"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def native_value(self):
-        """ Return time remaining on timer. """
+        """Return time remaining on timer."""
 
         total_time = round((float(self.purifier_data.timer_remaining) / 60), 2)
         hours, minutes = int(total_time), round(((total_time - int(total_time)) * 60))
@@ -407,13 +409,13 @@ class TimerRemaining(CoordinatorEntity, SensorEntity):
 
     @property
     def icon(self):
-        """ Set icon for entity. """
+        """Set icon for entity."""
 
         return 'mdi:timer'
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True

--- a/custom_components/coway/strings.json
+++ b/custom_components/coway/strings.json
@@ -19,7 +19,6 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
-      "incorrect_user_pass": "Invalid username and/or password for selected account",
       "invalid_auth": "Coway API authentication error: unable to retrieve auth 'code'. Likely due to invalid username/password.",
       "no_purifiers": "No purifiers discovered"
     },

--- a/custom_components/coway/switch.py
+++ b/custom_components/coway/switch.py
@@ -1,12 +1,11 @@
-""" Switch platform for Coway integration. """
+"""Switch platform for Coway integration."""
 from __future__ import annotations
 
 from typing import Any
 
-
 from cowayaio.purifier_model import CowayPurifier
-from homeassistant.components.switch import SwitchEntity
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -15,15 +14,15 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, LOGGER
 from .coordinator import CowayDataUpdateCoordinator
 
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """ Set Up Coway Switch Entities. """
+    """Set Up Coway Switch Entities."""
 
     coordinator: CowayDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     switches = []
-
 
     for purifier_id, purifier_data in coordinator.data.purifiers.items():
             switches.extend((
@@ -34,7 +33,7 @@ async def async_setup_entry(
 
 
 class PurifierLight(CoordinatorEntity, SwitchEntity):
-    """ Representation of purifier light switch. """
+    """Representation of purifier light switch."""
 
     def __init__(self, coordinator, purifier_id):
         super().__init__(coordinator)
@@ -42,13 +41,13 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
 
     @property
     def purifier_data(self) -> CowayPurifier:
-        """ Handle coordinator purifier data. """
+        """Handle coordinator purifier data."""
 
         return self.coordinator.data.purifiers[self.purifier_id]
 
     @property
     def device_info(self) -> dict[str, Any]:
-        """ Return device registry information for this entity. """
+        """Return device registry information for this entity."""
 
         return {
             "identifiers": {(DOMAIN, self.purifier_data.device_attr['device_id'])},
@@ -59,31 +58,31 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
 
     @property
     def unique_id(self) -> str:
-        """ Sets unique ID for this entity. """
+        """Sets unique ID for this entity."""
 
         return self.purifier_data.device_attr['device_id'] + '_light'
 
     @property
     def name(self) -> str:
-        """ Return name of the entity. """
+        """Return name of the entity."""
 
         return "Light"
 
     @property
     def has_entity_name(self) -> bool:
-        """ Indicate that entity has name defined. """
+        """Indicate that entity has name defined."""
 
         return True
 
     @property
     def icon(self) -> str:
-        """ Set purifier switch icon to lightbulb. """
+        """Set purifier switch icon to lightbulb."""
 
         return 'mdi:lightbulb'
 
     @property
     def is_on(self) -> bool:
-        """ Return true if light AND purifier are on. """
+        """Return true if light AND purifier are on."""
 
         if self.purifier_data.is_on and self.purifier_data.light_on:
             return True
@@ -91,7 +90,7 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
             return False
 
     async def async_turn_on(self, **kwargs) -> None:
-        """ Turn the switch on. """
+        """Turn the switch on."""
 
         if self.purifier_data.is_on:
             await self.coordinator.client.async_set_light(self.purifier_data.device_attr, True)
@@ -99,11 +98,12 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
         else:
             LOGGER.error(f'{self.purifier_data.device_attr["name"]} light can only be controlled when the purifier is On.')
             self.purifier_data.light_on = False
+
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
-        """ Turn the switch off. """
+        """Turn the switch off."""
 
         if self.purifier_data.is_on:
             await self.coordinator.client.async_set_light(self.purifier_data.device_attr, False)
@@ -111,12 +111,13 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
         else:
             LOGGER.error(f'{self.purifier_data.device_attr["name"]} light can only be controlled when the purifier is On.')
             self.purifier_data.light_on = False
+
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     @property
     def available(self) -> bool:
-        """ Return true if purifier is connected to Coway servers. """
+        """Return true if purifier is connected to Coway servers."""
 
         if self.purifier_data.network_status:
             return True

--- a/custom_components/coway/translations/en.json
+++ b/custom_components/coway/translations/en.json
@@ -6,7 +6,6 @@
         },
         "error": {
             "cannot_connect": "Failed to connect to Coway servers",
-            "incorrect_user_pass": "Invalid username and/or password for selected account",
             "invalid_auth": "Coway API authentication error: unable to retrieve auth 'code'. Likely due to invalid username/password.",
             "no_purifiers": "No purifiers discovered"
         },

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Coway IoCare",
   "render_readme": true,
-  "homeassistant": "2022.5.0b0"
+  "homeassistant": "2022.9.0"
 }


### PR DESCRIPTION
- Create a single instance of `CowayClient` that is used during the initial config flow and afterwards by the update coordinator. In the past, the creation of two CowayClient objects during initial integration configuration caused errors as Coway's servers don't like rapid back-to-back logins.
- Improved conformation to PEP8