### PR TITLE
Add PM2.5 support for IconS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Each purifier has the following entities:
 | `MAX2 Filter` | `Sensor` | Percentage of MAX2 filter life remaining |
 | `Pre Filter` | `Sensor` | Percentage of Pre filter remaining |
 | `Particulate Matter 10` | `Sensor` | |
+| `Particulate Matter 2.5` | `Sensor` | |
 | `Timer remaining` | `Sensor` | Shows the current amount of time left on a timer. This is a string in the form of hours:minutes |
 | `Indoor air quality` | `Sensor` | Shows the current indoor air quality based on Coway's scale. The state can be Good, Moderate, Unhealthy, or Very Unhealthy. |
 | `Pre-filter wash frequency` | `Select` | Shows current pre-filter wash frequency setting and allows you to change it. |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Each purifier has the following entities:
 | `Particulate Matter 10` | `Sensor` | Not available for IconS purifiers. |
 | `Particulate Matter 2.5` | `Sensor` | Only available for IconS purifiers. |
 | `Timer remaining` | `Sensor` | Shows the current amount of time left on a timer. This is a string in the form of hours:minutes |
-| `Indoor air quality` | `Sensor` | Shows the current indoor air quality based on Coway's scale. The state can be Good, Moderate, Unhealthy, or Very Unhealthy. |
+| `Indoor air quality` | `Sensor` | Shows the current indoor air quality based on Coway's scale. The state can be Good, Moderate, Unhealthy, or Very Unhealthy. Not available for IconS purifiers. |
 | `Pre-filter wash frequency` | `Select` | Shows current pre-filter wash frequency setting and allows you to change it. |
 | `Smart mode sensitivity` | `Select` | Shows current smart mode sensitivity setting and allows you to change it. |
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 300S
 - 400S
 - AP-1512HHS
+- IconS
 
 ## Installation
 
@@ -70,8 +71,8 @@ Each purifier has the following entities:
 | `AQI` | `Sensor` | Air Quality Index |
 | `MAX2 Filter` | `Sensor` | Percentage of MAX2 filter life remaining |
 | `Pre Filter` | `Sensor` | Percentage of Pre filter remaining |
-| `Particulate Matter 10` | `Sensor` | |
-| `Particulate Matter 2.5` | `Sensor` | |
+| `Particulate Matter 10` | `Sensor` | Not available for IconS purifiers. |
+| `Particulate Matter 2.5` | `Sensor` | Only available for IconS purifiers. |
 | `Timer remaining` | `Sensor` | Shows the current amount of time left on a timer. This is a string in the form of hours:minutes |
 | `Indoor air quality` | `Sensor` | Shows the current indoor air quality based on Coway's scale. The state can be Good, Moderate, Unhealthy, or Very Unhealthy. |
 | `Pre-filter wash frequency` | `Select` | Shows current pre-filter wash frequency setting and allows you to change it. |

--- a/custom_components/coway/manifest.json
+++ b/custom_components/coway/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "cowayaio==0.1.8"
   ],
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -42,7 +42,6 @@ async def async_setup_entry(
                 PreFilter(coordinator, purifier_id),
                 MAX2Filter(coordinator, purifier_id),
                 TimerRemaining(coordinator, purifier_id),
-                IndoorAQ(coordinator, purifier_id),
             ))
 
             product_name = purifier_data.device_attr['product_name']
@@ -50,7 +49,10 @@ async def async_setup_entry(
                 case "AIRMEGA_ICONS":
                     sensors.append(ParticulateMatter25(coordinator, purifier_id))
                 case _:
-                    sensors.append(ParticulateMatter10(coordinator, purifier_id))
+                    sensors.extend((
+                        ParticulateMatter10(coordinator, purifier_id),
+                        IndoorAQ(coordinator, purifier_id),
+                    ))
 
 
     async_add_entities(sensors)

--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -46,15 +46,11 @@ async def async_setup_entry(
             ))
 
             product_name = purifier_data.device_attr['product_name']
-            match purifier_data.device_attr['product_name']:
+            match product_name:
                 case "AIRMEGA_ICONS":
-                    sensors.extend((
-                        ParticulateMatter25(coordinator, purifier_id),
-                    ))
+                    sensors.append(ParticulateMatter25(coordinator, purifier_id))
                 case _:
-                    sensors.extend((
-                        ParticulateMatter10(coordinator, purifier_id),
-                    ))
+                    sensors.append(ParticulateMatter10(coordinator, purifier_id))
 
 
     async_add_entities(sensors)
@@ -333,7 +329,7 @@ class ParticulateMatter10(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return current PM10 measurement."""
-        return self.purifier_data.particulate_matter_10
+        return int(self.purifier_data.particulate_matter_10)
 
     @property
     def native_unit_of_measurement(self) -> str:
@@ -413,7 +409,7 @@ class ParticulateMatter25(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return current PM2.5 measurement."""
-        return self.purifier_data.particulate_matter_2_5
+        return int(self.purifier_data.particulate_matter_2_5)
 
     @property
     def native_unit_of_measurement(self) -> str:


### PR DESCRIPTION
IconS devices don't report AQI or PM10, but do report PM2.5 both on the device's display and via the API. Add a new sensor for PM2.5.

Also make sure we clamp the values for both PM10 and PM2.5 to 0 instead of empty string -- that squelches a lot of HASS complaints because sensors of type "measurement" need to be numeric. In order to reflect that 0 isn't a real measurement, mark the sensors as unavailable when the reported value(s) are empty strings.

Finally, bump version to 0.3.0.