### PR TITLE
Fix AirMega 250s Detection for EU Version

### DIFF
--- a/custom_components/coway/fan.py
+++ b/custom_components/coway/fan.py
@@ -110,7 +110,7 @@ class Purifier(CoordinatorEntity, FanEntity):
 
         if self.purifier_data.device_attr['model'] == "AIRMEGA AP-1512HHS":
             return PRESET_MODES_AP
-        elif self.purifier_data.device_attr['product_name'] == 'COLUMBIA':
+        elif self.purifier_data.device_attr['product_name'] in ['COLUMBIA', 'COLUMBIA_EU']:
             if self.purifier_data.fan_speed == '9':
                 return PRESET_MODES_250_WITH_ECO
             else:
@@ -130,7 +130,7 @@ class Purifier(CoordinatorEntity, FanEntity):
                 return PRESET_MODE_AUTO
             if self.purifier_data.eco_mode:
                 return PRESET_MODE_ECO
-        elif self.purifier_data.device_attr['product_name'] == 'COLUMBIA':
+        elif self.purifier_data.device_attr['product_name'] in ['COLUMBIA', 'COLUMBIA_EU']:
             # Fan speed of 9 is seen when in Auto Eco mode
             # for 250S purifiers
             if self.purifier_data.fan_speed == '9':
@@ -160,7 +160,7 @@ class Purifier(CoordinatorEntity, FanEntity):
         ## Neither of these speeds is a valid user-selectable speed so, in HA, we need to artifically
         ## show the speed as being 0, which is in line with the IoCare app showing no speed selected
         ## when in either of these two modes.
-        if self.purifier_data.device_attr['product_name'] == 'COLUMBIA':
+        if self.purifier_data.device_attr['product_name'] in ['COLUMBIA', 'COLUMBIA_EU']:
             if self.purifier_data.fan_speed in ['5', '9']:
                 return IOCARE_FAN_SPEED_TO_HASS.get(IOCARE_FAN_OFF)
         if self.preset_mode == PRESET_MODE_AUTO_ECO:

--- a/custom_components/coway/select.py
+++ b/custom_components/coway/select.py
@@ -48,7 +48,7 @@ async def async_setup_entry(
     for purifier_id, purifier_data in coordinator.data.purifiers.items():
             product_name = purifier_data.device_attr['product_name']
             #250S purifier has multiple light modes
-            if product_name in ['COLUMBIA']:
+            if product_name in ['COLUMBIA', 'COLUMBIA_EU']:
                 selects.append(Light(coordinator, purifier_id))
             selects.extend((
                 Timer(coordinator, purifier_id),

--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
             # PM and Air Quality sensor availability depends on the purfier model
             # COLUMBIA = 250S
             product_name = purifier_data.device_attr['product_name']
-            if product_name in ["AIRMEGA_ICONS", "COLUMBIA"]:
+            if product_name in ["AIRMEGA_ICONS", "COLUMBIA", "COLUMBIA_EU"]:
                 sensors.append(ParticulateMatter25(coordinator, purifier_id))
             if product_name != "AIRMEGA_ICONS":
                 sensors.extend((

--- a/custom_components/coway/switch.py
+++ b/custom_components/coway/switch.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
 
     for purifier_id, purifier_data in coordinator.data.purifiers.items():
         product_name = purifier_data.device_attr['product_name']
-        if product_name not in ['COLUMBIA']:
+        if product_name not in ['COLUMBIA', 'COLUMBIA_EU']:
             switches.extend((
                 PurifierLight(coordinator, purifier_id),
             ))


### PR DESCRIPTION
Just got a Coway AirMega 250s and it was not detected correctly, looking at the device data in the logs, I see that the product name is `COLUMBIA_EU` not just `COLUMBIA`, which kinda makes sense since I'm in the EU.

This change just modifies the different conditions to check for both cases

Here is a dump of the product data

```json
{
    "purifiers": {
        "[REDACTED]": {
            "device_attr": {
                "device_id": "[REDACTED]",
                "model": "AP-1720G_GR",
                "name": "Coway Living Air Purifier",
                "product_name": "COLUMBIA_EU",
                "product_name_full": "\ucf5c\ub86c\ube44\uc544(COLUMBIA) \uc720\ub7fd\ud5a5",
                "device_type": "004",
                "device_brand": "MG",
                "device_seq": [REDACTED],
                "order_number": "[REDACTED]"
            },
            "mcu_version": "V1.0.0.4",
            "network_status": true,
            "is_on": true,
            "auto_mode": true,
            "auto_eco_mode": false,
            "eco_mode": false,
            "night_mode": false,
            "rapid_mode": false,
            "fan_speed": "1",
            "light_on": false,
            "light_mode": "0",
            "timer": null,
            "timer_remaining": "0",
            "pre_filter_name": "\uadf9\uc138\uc0ac\ub9dd \ud504\ub9ac\ud544\ud130",
            "pre_filter_pct": 100,
            "pre_filter_last_changed": "20240528",
            "pre_filter_change_months": "3",
            "max2_name": "Max2 \ud544\ud130",
            "max2_pct": 100,
            "max2_last_changed": "20240528",
            "max2_change_months": "12",
            "dust_pollution": "1",
            "air_volume": "1",
            "pollen_mode": "",
            "particulate_matter_2_5": "7",
            "particulate_matter_10": "12",
            "carbon_dioxide": "",
            "volatile_organic_compounds": "",
            "air_quality_index": "",
            "pre_filter_change_frequency": 3,
            "smart_mode_sensitivity": 1
        }
    }
}
```