### PR TITLE
Indicator light switch: state-dependent icon

### DIFF
--- a/custom_components/coway/switch.py
+++ b/custom_components/coway/switch.py
@@ -83,7 +83,12 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
     def icon(self) -> str:
         """Set purifier switch icon to lightbulb."""
 
-        return 'mdi:lightbulb'
+        if self.is_on:
+            return 'mdi:led-on'
+        elif self.purifier_data.is_on:
+            return 'mdi:led-off'
+        else:
+            return 'mdi:led-variant-off'
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
- is_on: lit led
- light off but purifier on: unlit led (mdi:led-off)
- light off and purifier off: crossed-out led

This matches your current design scheme (use of crossing out to indicate disabled, using all filled in icons rather than outlines even for off states)