### PR TITLE
fix: replace deprecated datetime.utcfromtimestamp()

### DIFF
--- a/custom_components/coway/coordinator.py
+++ b/custom_components/coway/coordinator.py
@@ -90,7 +90,7 @@ class CowayDataUpdateCoordinator(DataUpdateCoordinator):
                                 raise ServerMaintenance(
                                     f'Coway servers are currently undergoing planned maintenance. '
                                     f'Polling suspended. Will try polling again/checking if maintenance '
-                                    f'has ended at {datetime.utcfromtimestamp(self.cooldown).strftime("%m/%d/%Y, %H:%M")}'
+                                    f'has ended at {datetime.fromtimestamp(self.cooldown, tz=timezone.utc).strftime("%m/%d/%Y, %H:%M")}'
                                 )
                             else:
                                 self.hass.config_entries.async_update_entry(self.entry, data=null_maint_data)
@@ -110,7 +110,7 @@ class CowayDataUpdateCoordinator(DataUpdateCoordinator):
                         raise ServerMaintenance(
                             f'Coway servers are currently undergoing planned maintenance. '
                             f'Polling suspended. Will try polling again/checking if maintenance '
-                            f'has ended at {datetime.utcfromtimestamp(self.cooldown).strftime("%m/%d/%Y, %H:%M")}'
+                            f'has ended at {datetime.fromtimestamp(self.cooldown, tz=timezone.utc).strftime("%m/%d/%Y, %H:%M")}'
                         )
                     else:
                         # Reset cooldown as an hour has passed.


### PR DESCRIPTION
## What changed
Replaced `datetime.utcfromtimestamp(self.cooldown)` with `datetime.fromtimestamp(self.cooldown, tz=timezone.utc)` in two places in `coordinator.py`.

## Why
`datetime.utcfromtimestamp()` has been deprecated since Python 3.12 and is scheduled for removal in a future Python version. It returns a naive datetime that can be misinterpreted as local time. The replacement `datetime.fromtimestamp(timestamp, tz=timezone.utc)` is the recommended timezone-aware alternative that explicitly marks the result as UTC.

**Before:**
```python
datetime.utcfromtimestamp(self.cooldown).strftime(...)
```

**After:**
```python
datetime.fromtimestamp(self.cooldown, tz=timezone.utc).strftime(...)
```

Ref: https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp