### PR TITLE
fix: preserve exception chain for PasswordExpired

### DIFF
--- a/custom_components/coway/coordinator.py
+++ b/custom_components/coway/coordinator.py
@@ -162,7 +162,7 @@ class CowayDataUpdateCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed(
                 f"Coway servers are requesting a password change as the password on this account hasn't been changed for 60 days or more. "
                 f"Either use the IoCare app to change your password or reauthenticate the integration with the skip password change option."
-            )
+            ) from error
         except CowayError as error:
             raise UpdateFailed(error) from error
 


### PR DESCRIPTION
## What changed
Added missing `from error` to the `PasswordExpired` except block in `coordinator.py` `_async_update_data()`.

## Why
Every other except block in this method correctly chains exceptions using `from error` (e.g. `raise UpdateFailed(error) from error`), but the `PasswordExpired` handler was missing it.

Without `from error`, Python implicitly suppresses the original exception context, making debugging significantly harder — the original traceback and root cause are lost.

**Before:**
```python
except PasswordExpired as error:
    raise ConfigEntryAuthFailed(
        f"Coway servers are requesting a password change..."
    )
```

**After:**
```python
except PasswordExpired as error:
    raise ConfigEntryAuthFailed(
        f"Coway servers are requesting a password change..."
    ) from error
```
