### PR TITLE
fix: prevent preset_mode and percentage from returning None

### DIFF
--- a/custom_components/coway/fan.py
+++ b/custom_components/coway/fan.py
@@ -122,7 +122,7 @@ class Purifier(CoordinatorEntity, FanEntity):
                 return PRESET_MODES
 
     @property
-    def preset_mode(self) -> str:
+    def preset_mode(self) -> str | None:
         """Return the current preset mode."""
 
         if self.purifier_data.device_attr['model_code'] == "AP-1512HHS":
@@ -148,6 +148,7 @@ class Purifier(CoordinatorEntity, FanEntity):
                 return PRESET_MODE_AUTO
             if self.purifier_data.night_mode:
                 return PRESET_MODE_NIGHT
+        return None
 
     @property
     def percentage(self) -> int:
@@ -162,10 +163,10 @@ class Purifier(CoordinatorEntity, FanEntity):
         ## when in either of these two modes.
         if self.purifier_data.device_attr['model'] == "Airmega 250S":
             if self.purifier_data.fan_speed in [5, 9]:
-                return IOCARE_FAN_SPEED_TO_HASS.get(IOCARE_FAN_OFF)
+                return IOCARE_FAN_SPEED_TO_HASS.get(IOCARE_FAN_OFF, 0)
         if self.preset_mode == PRESET_MODE_AUTO_ECO:
-            return IOCARE_FAN_SPEED_TO_HASS.get(IOCARE_FAN_OFF)
-        return IOCARE_FAN_SPEED_TO_HASS.get(self.purifier_data.fan_speed)
+            return IOCARE_FAN_SPEED_TO_HASS.get(IOCARE_FAN_OFF, 0)
+        return IOCARE_FAN_SPEED_TO_HASS.get(self.purifier_data.fan_speed, 0)
 
     @property
     def speed_count(self) -> int:


### PR DESCRIPTION
## What changed
Fixed two properties in `fan.py` (`Purifier` entity) that could return `None` unexpectedly.

### `preset_mode` property
- Added an explicit `return None` at the end of the method
- Corrected return type annotation from `str` to `str | None`

### `percentage` property
- Added default value of `0` to all `IOCARE_FAN_SPEED_TO_HASS.get()` calls

## Why

### `preset_mode`
Previously, when no preset mode flag was active (e.g., when the purifier is running at a manual fan speed), all conditional branches would be skipped and the property would implicitly return `None`. While `None` is a valid return for "no preset mode active", the implicit return made it unclear whether this was intentional or a bug. The type annotation also incorrectly declared `str` instead of `str | None`.

### `percentage`
`dict.get()` without a default returns `None` when the key is missing. If the purifier reports an unexpected fan speed value not present in the `IOCARE_FAN_SPEED_TO_HASS` mapping, the property would return `None` instead of `int`, violating its type contract and potentially causing Home Assistant state machine errors. Adding `0` as the default ensures the return type is always `int`.

**Before:**
```python
def preset_mode(self) -> str:
    ...
    # implicit return None — unclear intent

def percentage(self) -> int:
    ...
    return IOCARE_FAN_SPEED_TO_HASS.get(self.purifier_data.fan_speed)  # can return None
```

**After:**
```python
def preset_mode(self) -> str | None:
    ...
    return None  # explicit — no preset mode active

def percentage(self) -> int:
    ...
    return IOCARE_FAN_SPEED_TO_HASS.get(self.purifier_data.fan_speed, 0)  # always returns int
```
