### PR TITLE
fix: replace deprecated async_timeout with asyncio.timeout

### DIFF
--- a/custom_components/coway/util.py
+++ b/custom_components/coway/util.py
@@ -1,7 +1,7 @@
 """Utilities for Coway Integration"""
 from __future__ import annotations
 
-import async_timeout
+import asyncio
 
 from aiohttp import ClientSession
 from cowayaio import CowayClient
@@ -40,7 +40,7 @@ async def async_validate_api(
     client.skip_password_change = True
 
     try:
-        async with async_timeout.timeout(TIMEOUT):
+        async with asyncio.timeout(TIMEOUT):
             await client.async_get_purifiers_data()
     except ServerMaintenance as err:
         raise ServerMaintenance from err


### PR DESCRIPTION
## What changed
Replaced `async_timeout.timeout()` with `asyncio.timeout()` in `util.py`.

## Why
`asyncio.timeout()` was added in Python 3.11 as the stdlib replacement for the third-party `async_timeout` package. Home Assistant requires Python 3.12+ and has been migrating away from `async_timeout` across the codebase. This removes an unnecessary external dependency in favor of the built-in equivalent.

**Before:**
```python
import async_timeout

async with async_timeout.timeout(TIMEOUT):
    await client.async_get_purifiers_data()
```

**After:**
```python
import asyncio

async with asyncio.timeout(TIMEOUT):
    await client.async_get_purifiers_data()
```

Ref: https://docs.python.org/3.11/library/asyncio-task.html#asyncio.timeout
