### PR TITLE
fix: disambiguate unique_id between select.Light and switch.PurifierLight

### DIFF
--- a/custom_components/coway/select.py
+++ b/custom_components/coway/select.py
@@ -388,7 +388,7 @@ class Light(CoordinatorEntity, SelectEntity):
     def unique_id(self) -> str:
         """Sets unique ID for this entity."""
 
-        return self.purifier_data.device_attr['device_id'] + '_light'
+        return self.purifier_data.device_attr['device_id'] + '_light_mode'
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## What changed
Renamed the `unique_id` suffix for the `Light` select entity (used by 250S/IconS models) from `_light` to `_light_mode` in `select.py`.

## Why
Both `select.Light` (in `select.py`) and `switch.PurifierLight` (in `switch.py`) use the same `_light` suffix for their `unique_id`. The current model-based filtering logic prevents actual collisions at runtime — 250S/IconS models get the select entity, while all other models get the switch entity.

However, sharing the same `unique_id` suffix across two different entity platforms is fragile. If the model filtering logic ever changes (e.g., a new model that supports both), entity IDs would conflict, causing HA to silently drop one of the entities.

The new suffix `_light_mode` also better describes the select entity's purpose — it selects between light *modes* (On/Off/AQI Off/Half Off), whereas the switch is a simple on/off toggle.

**Before:**
\`\`\`python
# select.py - Light entity
return self.purifier_data.device_attr['device_id'] + '_light'

# switch.py - PurifierLight entity  
return self.purifier_data.device_attr['device_id'] + '_light'
# Same suffix!
\`\`\`

**After:**
\`\`\`python
# select.py - Light entity
return self.purifier_data.device_attr['device_id'] + '_light_mode'

# switch.py - PurifierLight entity (unchanged)
return self.purifier_data.device_attr['device_id'] + '_light'
\`\`\`

**Note:** Existing users with 250S/IconS models will see a new entity created with the updated ID. The old entity can be removed from the entity registry.
