### PR TITLE
fix: remove synchronous file I/O at module import time

### DIFF
--- a/custom_components/coway/__init__.py
+++ b/custom_components/coway/__init__.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import json
-import os
+from pathlib import Path
 
 from cowayaio.__version__ import __version__ as coway_aio_version
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
 
 from .const import (
     COWAY_COORDINATOR,
@@ -25,18 +26,14 @@ from .const import (
 from .coordinator import CowayDataUpdateCoordinator
 
 
-curr_dir = os.path.dirname(__file__)
-manifest_path = os.path.join(curr_dir, 'manifest.json')
-with open(manifest_path, 'r') as file:
-    json_file = json.load(file)
-INTEGRATION_VERSION = json_file.get("version")
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Coway from a config entry."""
 
+    integration = await async_get_integration(hass, DOMAIN)
+    integration_version = integration.version
+
     LOGGER.debug(
-        f'Starting Coway integration {INTEGRATION_VERSION}/CowayAIO {coway_aio_version}'
+        f'Starting Coway integration {integration_version}/CowayAIO {coway_aio_version}'
     )
 
     null_maint_data = {


### PR DESCRIPTION
## What changed
Replaced the module-level synchronous `open()`/`json.load()` of `manifest.json` in `__init__.py` with Home Assistant's `async_get_integration()` API.

## Why
The previous code performed blocking disk I/O during module import, which runs on the event loop:

```python
curr_dir = os.path.dirname(__file__)
manifest_path = os.path.join(curr_dir, 'manifest.json')
with open(manifest_path, 'r') as file:
    json_file = json.load(file)
INTEGRATION_VERSION = json_file.get("version")
```

This blocks the event loop and can delay other async tasks during startup. Additionally, HA's integration loader already parses `manifest.json`, so reading it again is redundant.

**After:**
```python
integration = await async_get_integration(hass, DOMAIN)
integration_version = integration.version
```

The version is now retrieved asynchronously inside `async_setup_entry()` using HA's built-in loader, which already has the manifest cached. This also removes the unused `os` import.
