### PR TITLE
fix: use elif for mutually exclusive version checks in async_migrate_entry

### DIFF
--- a/custom_components/coway/__init__.py
+++ b/custom_components/coway/__init__.py
@@ -101,7 +101,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             },
             unique_id=username,
         )
-    if entry.version == 2:
+    elif entry.version == 2:
         LOGGER.debug(
             'Migrating Coway config: disabling skipping password change, setting polling '
             'interval of 120, and adding maintenance_cooldown key'
@@ -121,7 +121,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 POLLING_INTERVAL: 120
             },
         )
-    if entry.version == 3:
+    elif entry.version == 3:
         LOGGER.debug(
             'Migrating Coway config: setting polling interval of '
             '120, and adding maintenance_cooldown key'
@@ -142,7 +142,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             },
         )
 
-    if entry.version == 4:
+    elif entry.version == 4:
         LOGGER.debug(
             'Migrating Coway config: adding maintenance_cooldown key'
         )


### PR DESCRIPTION
## What changed
Changed separate `if` statements to an `elif` chain for the config entry version checks (v1, v2, v3, v4) in `async_migrate_entry()` in `__init__.py`.

## Why
The version checks are mutually exclusive — a config entry can only be at one version at a time. Using separate `if` statements implies each condition is independent and could match simultaneously, which is misleading.

While the current code works correctly (because migrating from v1 updates the version to v5, so v2/v3/v4 won't match), using `elif` makes the mutual exclusivity explicit and avoids unnecessary evaluation of subsequent conditions after a match.

**Before:**
```python
if entry.version == 1:
    ...
if entry.version == 2:
    ...
if entry.version == 3:
    ...
if entry.version == 4:
    ...
```

**After:**
```python
if entry.version == 1:
    ...
elif entry.version == 2:
    ...
elif entry.version == 3:
    ...
elif entry.version == 4:
    ...
```
