### PR TITLE
fix: correct supported_features return type from int to FanEntityFeature

### DIFF
--- a/custom_components/coway/fan.py
+++ b/custom_components/coway/fan.py
@@ -174,7 +174,7 @@ class Purifier(CoordinatorEntity, FanEntity):
         return len(ORDERED_NAMED_FAN_SPEEDS)
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> FanEntityFeature:
         """Return supported features."""
 
         return (


### PR DESCRIPTION
## Summary

Corrects the return type annotation of the `supported_features` property in `CowayFanEntity` from `int` to `FanEntityFeature`.

## Before

```python
@property
def supported_features(self) -> int:
    return (
        FanEntityFeature.SET_SPEED
        | FanEntityFeature.PRESET_MODE
        | FanEntityFeature.TURN_ON
        | FanEntityFeature.TURN_OFF
    )
```

## After

```python
@property
def supported_features(self) -> FanEntityFeature:
    return (
        FanEntityFeature.SET_SPEED
        | FanEntityFeature.PRESET_MODE
        | FanEntityFeature.TURN_ON
        | FanEntityFeature.TURN_OFF
    )
```

## Why

The property returns a combination of `FanEntityFeature` flags, not a plain `int`. While `FanEntityFeature` is backed by `IntFlag` (and therefore is an `int` subtype), the correct and idiomatic Home Assistant return type is `FanEntityFeature`. This aligns with the base class definition in Home Assistant core and improves type safety and editor tooling support.
