### PR TITLE
fix: guard TimerRemaining against hours >= 24 ValueError

### DIFF
--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import time
 from typing import Any
 
 from cowayaio.purifier_model import CowayPurifier
@@ -503,13 +502,12 @@ class TimerRemaining(CoordinatorEntity, SensorEntity):
         return True
 
     @property
-    def native_value(self):
+    def native_value(self) -> str:
         """Return time remaining on timer."""
 
-        total_time = round((float(self.purifier_data.timer_remaining) / 60), 2)
-        hours, minutes = int(total_time), round(((total_time - int(total_time)) * 60))
-        timer_remaining = time(hour = hours, minute = minutes)
-        return timer_remaining.isoformat(timespec = "minutes")
+        total_minutes = round(float(self.purifier_data.timer_remaining))
+        hours, minutes = divmod(total_minutes, 60)
+        return f"{hours:02d}:{minutes:02d}"
 
     @property
     def icon(self):


### PR DESCRIPTION
## Summary

Fixes a potential `ValueError` in `TimerRemaining.native_value` when the timer remaining exceeds 23 hours (1440 minutes).

## Before

```python
from datetime import time

# ...

@property
def native_value(self):
    """Return time remaining on timer."""

    total_time = round((float(self.purifier_data.timer_remaining) / 60), 2)
    hours, minutes = int(total_time), round(((total_time - int(total_time)) * 60))
    timer_remaining = time(hour = hours, minute = minutes)
    return timer_remaining.isoformat(timespec = "minutes")
```

## After

```python
@property
def native_value(self) -> str:
    """Return time remaining on timer."""

    total_minutes = round(float(self.purifier_data.timer_remaining))
    hours, minutes = divmod(total_minutes, 60)
    return f"{hours:02d}:{minutes:02d}"
```

## Why

`datetime.time()` only accepts hours in the range 0–23. If `timer_remaining` is 1440 minutes or more (≥ 24 hours), the previous code would crash with a `ValueError`. This change:

1. **Eliminates the crash**: Uses `divmod()` and f-string formatting, which works for any non-negative number of hours.
2. **Simplifies the logic**: Replaces the multi-step float arithmetic with a clean, easy-to-follow `divmod` call.
3. **Removes the unused import**: The `from datetime import time` import is no longer needed.
4. **Adds a return type annotation**: The property now declares `-> str`.

The output format ("HH:MM") remains the same for values under 24 hours.
