### PR TITLE
fix: replace deprecated FlowResult with ConfigFlowResult

### DIFF
--- a/custom_components/coway/config_flow.py
+++ b/custom_components/coway/config_flow.py
@@ -15,9 +15,9 @@ from cowayaio.exceptions import (
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
 
@@ -55,7 +55,7 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return CowayOptionsFlowHandler()
 
-    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> ConfigFlowResult:
         """Handle re-authentication with Coway."""
 
         self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
@@ -63,7 +63,7 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth_confirm(
             self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Confirm re-authentication with Coway."""
 
         errors: dict[str, str] = {}
@@ -116,7 +116,7 @@ class CowayConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
             self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
 
         errors: dict[str, str] = {}


### PR DESCRIPTION
## Summary

Replaces the deprecated `FlowResult` type with the newer `ConfigFlowResult` in all config flow method signatures.

## Before

```python
from homeassistant.data_entry_flow import FlowResult

# ...

async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
async def async_step_reauth_confirm(self, user_input: ...) -> FlowResult:
async def async_step_user(self, user_input: ...) -> FlowResult:
```

## After

```python
from homeassistant.config_entries import ConfigFlowResult

# ...

async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> ConfigFlowResult:
async def async_step_reauth_confirm(self, user_input: ...) -> ConfigFlowResult:
async def async_step_user(self, user_input: ...) -> ConfigFlowResult:
```

## Why

`FlowResult` from `homeassistant.data_entry_flow` has been deprecated in Home Assistant core. The recommended replacement is `ConfigFlowResult` from `homeassistant.config_entries`, which is a more specific type that better represents the actual return values of config flow step methods.

This change aligns the integration with current Home Assistant development best practices and prevents deprecation warnings.
