### PR TITLE
fix: simplify verbose boolean returns across entity files

### DIFF
--- a/custom_components/coway/select.py
+++ b/custom_components/coway/select.py
@@ -130,10 +130,7 @@ class Timer(CoordinatorEntity, SelectEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -230,10 +227,7 @@ class PreFilterFrequency(CoordinatorEntity, SelectEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -329,10 +323,7 @@ class SmartModeSensitivity(CoordinatorEntity, SelectEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -427,10 +418,7 @@ class Light(CoordinatorEntity, SelectEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/coway/sensor.py
+++ b/custom_components/coway/sensor.py
@@ -129,10 +129,7 @@ class AirQualityIndex(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class PreFilter(CoordinatorEntity, SensorEntity):
@@ -213,10 +210,7 @@ class PreFilter(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class MAX2Filter(CoordinatorEntity, SensorEntity):
@@ -293,10 +287,7 @@ class MAX2Filter(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class ParticulateMatter10(CoordinatorEntity, SensorEntity):
@@ -374,10 +365,7 @@ class ParticulateMatter10(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 class ParticulateMatter25(CoordinatorEntity, SensorEntity):
     """Representation of PM2.5 measurement."""
@@ -454,10 +442,7 @@ class ParticulateMatter25(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class TimerRemaining(CoordinatorEntity, SensorEntity):
@@ -521,10 +506,7 @@ class TimerRemaining(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class IndoorAQ(CoordinatorEntity, SensorEntity):
@@ -590,10 +572,7 @@ class IndoorAQ(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class Lux(CoordinatorEntity, SensorEntity):
@@ -677,7 +656,4 @@ class Lux(CoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status

--- a/custom_components/coway/switch.py
+++ b/custom_components/coway/switch.py
@@ -94,10 +94,7 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return true if light AND purifier are on."""
 
-        if self.purifier_data.is_on and self.purifier_data.light_on:
-            return True
-        else:
-            return False
+        return self.purifier_data.is_on and self.purifier_data.light_on
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
@@ -147,10 +144,7 @@ class PurifierLight(CoordinatorEntity, SwitchEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status
 
 
 class ButtonLock(CoordinatorEntity, SwitchEntity):
@@ -208,10 +202,7 @@ class ButtonLock(CoordinatorEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return true if lock AND purifier are on."""
 
-        if self.purifier_data.is_on and self.purifier_data.button_lock == 1:
-            return True
-        else:
-            return False
+        return self.purifier_data.is_on and self.purifier_data.button_lock == 1
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
@@ -261,7 +252,4 @@ class ButtonLock(CoordinatorEntity, SwitchEntity):
     def available(self) -> bool:
         """Return true if purifier is connected to Coway servers."""
 
-        if self.purifier_data.network_status:
-            return True
-        else:
-            return False
+        return self.purifier_data.network_status


### PR DESCRIPTION
## Summary

Simplifies 16 verbose boolean return patterns across `sensor.py`, `select.py`, and `switch.py`.

## Before

```python
@property
def available(self) -> bool:
    """Return true if purifier is connected to Coway servers."""

    if self.purifier_data.network_status:
        return True
    else:
        return False

# switch.py — PurifierLight
@property
def is_on(self) -> bool:
    """Return true if light AND purifier are on."""

    if self.purifier_data.is_on and self.purifier_data.light_on:
        return True
    else:
        return False
```

## After

```python
@property
def available(self) -> bool:
    """Return true if purifier is connected to Coway servers."""

    return self.purifier_data.network_status

# switch.py — PurifierLight
@property
def is_on(self) -> bool:
    """Return true if light AND purifier are on."""

    return self.purifier_data.is_on and self.purifier_data.light_on
```

## Why

The pattern `if x: return True else: return False` is equivalent to `return x` when the expression is already truthy/falsy in a boolean context. The simplified form is:

- **More idiomatic** — standard Python style per PEP 8
- **Easier to read** — the intent is immediately clear
- **Less code** — removes 48 lines across 3 files

**Note:** The `fan.py` `available` property is intentionally excluded from this change because its `else` branch has a side effect (`LOGGER.error()`), so it cannot be simplified to a single return.

### Breakdown

| File | Occurrences simplified |
|------|----------------------|
| `sensor.py` | 8 (`available` in all sensor entities) |
| `select.py` | 4 (`available` in all select entities) |
| `switch.py` | 4 (2× `available` + 2× `is_on`) |
