### PR TITLE
fix: use elif for mutually exclusive preset mode checks in async_set_preset_mode

### DIFF
--- a/custom_components/coway/fan.py
+++ b/custom_components/coway/fan.py
@@ -307,7 +307,7 @@ class Purifier(CoordinatorEntity, FanEntity):
             self.purifier_data.eco_mode = False
             self.purifier_data.night_mode = False
             self.purifier_data.fan_speed = IOCARE_FAN_LOW
-        if preset_mode in [PRESET_MODE_NIGHT, PRESET_MODE_ECO]:
+        elif preset_mode in [PRESET_MODE_NIGHT, PRESET_MODE_ECO]:
             if self.purifier_data.device_attr['model_code'] == "AP-1512HHS":
                 try:
                     await self.coordinator.client.async_set_eco_mode(
@@ -327,7 +327,7 @@ class Purifier(CoordinatorEntity, FanEntity):
                 self.purifier_data.night_mode = True
             self.purifier_data.auto_mode = False
             self.purifier_data.fan_speed = IOCARE_FAN_OFF
-        if preset_mode == PRESET_MODE_RAPID:
+        elif preset_mode == PRESET_MODE_RAPID:
             try:
                 await self.coordinator.client.async_set_rapid_mode(
                     self.purifier_data.device_attr


### PR DESCRIPTION
## Summary

Changed independent `if` blocks to an `elif` chain for the mutually exclusive preset mode checks in `async_set_preset_mode()` in `fan.py`.

## Before

```python
if preset_mode == PRESET_MODE_AUTO:
    ...
if preset_mode in [PRESET_MODE_NIGHT, PRESET_MODE_ECO]:
    ...
if preset_mode == PRESET_MODE_RAPID:
    ...
```

## After

```python
if preset_mode == PRESET_MODE_AUTO:
    ...
elif preset_mode in [PRESET_MODE_NIGHT, PRESET_MODE_ECO]:
    ...
elif preset_mode == PRESET_MODE_RAPID:
    ...
```

## Why

A preset mode can only be one value at a time — `AUTO`, `NIGHT`/`ECO`, or `RAPID` are mutually exclusive. Using separate `if` statements implies each condition is independent and could match simultaneously, which is misleading.

Using `elif` makes the mutual exclusivity explicit and avoids unnecessary evaluation of subsequent conditions after a match. This is the same pattern as the migration version checks fix in `__init__.py`.

**Note:** The first two `if` blocks (`PRESET_MODE_AUTO_ECO` guard and `not self.is_on` power-on) remain as independent `if` statements since they are not mutually exclusive with the mode selection — one is a guard clause that raises, and the other is a precondition that runs before any mode is set.
